### PR TITLE
Fix for dual graphic card system

### DIFF
--- a/GpuCapabilityTester.cpp
+++ b/GpuCapabilityTester.cpp
@@ -149,8 +149,6 @@ GpuCapabilities GpuCapabilityTester::FindOptimalAdapter( const GpuRequirements& 
 		LogMessageLine( bD3d9Success ? "SUCCESS" : "FAILED");
 		rank += 100000;
 
-		caps.m_bD3d9Support = bD3d9Success;
-
 		LogMessageLine("\n   Visual Xccelerator Engine Direct3D11 Compatibility");
 
 		LogMessage("      Trying to create Direct3D9Ex Device (WPF Compatibility)... ");
@@ -186,8 +184,6 @@ GpuCapabilities GpuCapabilityTester::FindOptimalAdapter( const GpuRequirements& 
 			bD3d11Success = false;
 		}
 		LogMessageLine(bD3d11Success ? "SUCCESS" : "FAILED");
-
-		caps.m_bD3d11Support = bD3d9ExSuccess & bD3d11Success;
 
 		if (bD3d9ExSuccess && bD3d11Success)
 		{


### PR DESCRIPTION
The test result is wrong when there are more than one graphic cards. See results below:
```
### GPU Capability Test ###
   Is BGRA feature required: TRUE

Examining Graphics Adapter: NVIDIA GeForce MX150
   VRAM: 1983Mb
   DeiceId: 7442

   Visual Xccelerator Engine Direct3D9 Compatibility
      Trying to create Direct3D9 Device... SUCCESS

   Visual Xccelerator Engine Direct3D11 Compatibility
      Trying to create Direct3D9Ex Device (WPF Compatibility)... SUCCESS
      Trying to create Direct3D11 Device... SUCCESS

   Rank: 1101983 Points

Examining Graphics Adapter: Intel(R) UHD Graphics 620
   VRAM: 128Mb
   DeiceId: 16032

   Visual Xccelerator Engine Direct3D9 Compatibility
      Trying to create Direct3D9 Device... FAILED

   Visual Xccelerator Engine Direct3D11 Compatibility
      Trying to create Direct3D9Ex Device (WPF Compatibility)... FAILED
      Trying to create Direct3D11 Device... SUCCESS

      NOTE: the adapter is able to create Direct3D11 Device,
      hovewer for some reason it's unable to create DirectX9Ex Device.
      It looks like the adapter is not connected to a monitor.
      If you would like to run the SciChart on this adapter,
      please make sure that the monitor cable is plugged in.

      NOTE: the amount of Video Memory (VRAM) is low.
         If Visual Xccelerator Engine select this adapter,
         it will be running in low memory consumption mode.
         This might cause a performance drop or visual errors.

   Rank: 100128 Points

Selected Graphics Adapter, where DeviceId is: 7442
   Is Direct3D9 Supported: FALSE
   Is Direct3D11 Supported: FALSE
```

Here is a quick fix for this issue. 
This problem DOES prevent my laptop from enabling accelerated engine when using scichart > 6.2.